### PR TITLE
change 'PayPal for Marketplaces' to 'PayPal for Partners' in references and add api version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## PayPal for Marketplaces Managed path
+## PayPal for Partners Managed path
 
-> **Important:** PayPal for Marketplaces is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager.
+> **Important:** PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 ## PayPal for Partners Managed path
 
 > **Important:** PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. Two versions of the solution are available:
-
+>
 >New integrations: [version 2](https://developer.paypal.com/docs/partners/) (from February 2019)
-
+>
 >Existing integrations: [version 1](https://developer.paypal.com/docs/partners/v1/) (before February 2019)
-
+>
 >New customers should integrate version 2. For more information, reach out to your PayPal account manager.
 
 
->This code sample is not upgraded to use  [version 2](https://developer.paypal.com/docs/partners/).
+>This code sample is not upgraded to use [version 2](https://developer.paypal.com/docs/partners/).
 
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 ## PayPal for Partners Managed path
 
-> **Important:** PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager.
+> **Important:** PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. Two versions of the solution are available:
+
+>New integrations: [version 2](https://developer.paypal.com/docs/partners/) (from February 2019)
+
+>Existing integrations: [version 1](https://developer.paypal.com/docs/partners/v1/) (before February 2019)
+
+>New customers should integrate version 2. For more information, reach out to your PayPal account manager.
+
+
+>This code sample is not upgraded to use  [version 2](https://developer.paypal.com/docs/partners/).
+
 
 ## Prerequisites
 

--- a/include/incl.header.php
+++ b/include/incl.header.php
@@ -136,7 +136,7 @@
 		<div class="container-fluid">
 
             <div class="well bg-color">
-                <h2 class="text-center">PayPal for Marketplaces &bull; <a href="../index.php#readme" class="light-links">Readme</a></h2>
+                <h2 class="text-center">PayPal for Partners &bull; <a href="../index.php#readme" class="light-links">Readme</a></h2>
             </div>
             
         </div>

--- a/include/incl.indexheader.php
+++ b/include/incl.indexheader.php
@@ -136,7 +136,7 @@ $mode = (isset($_REQUEST["mode"]) &&  $_REQUEST["mode"] == "ma") ? "ma" : "isu";
 <div class="container-fluid">
 
     <div class="well bg-color">
-        <h2 class="text-center">PayPal for Marketplaces &bull; <a href="#readme" class="light-links">Readme</a></h2>
+        <h2 class="text-center">PayPal for Partners &bull; <a href="#readme" class="light-links">Readme</a></h2>
     </div>
 
 </div>

--- a/include/incl.readme.php
+++ b/include/incl.readme.php
@@ -1,11 +1,11 @@
 <h3>Readme</h3>
 
 <br />
-<b>Important:</b> PayPal for Marketplaces is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager or <a href="https://www.paypal.com/us/webapps/mpp/partner-program/contact-us" target="_blank">contact us</a>.
+<b>Important:</b> PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager or <a href="https://www.paypal.com/us/webapps/mpp/partner-program/contact-us" target="_blank">contact us</a>.
 <br/><br/>
 
 <h4>Getting Started</h4>
-This code sample serves as a reference for PayPal for Marketplaces APIs. You will need your own PayPal Sandbox Partner credentials to run the code sample.
+This code sample serves as a reference for PayPal for Partners APIs. You will need your own PayPal Sandbox Partner credentials to run the code sample.
 Once you have your Partner credentials, refer to the steps below:
 <br />
 <br />
@@ -114,7 +114,7 @@ A marketplace model in which merchant aren't required to have PayPal account.
 
 <h4>Documentation</h4>
 
-PayPal for Marketplaces: <a href="https://developer.paypal.com/docs/marketplaces/pp4mp/" target="_blank">https://developer.paypal.com/docs/marketplaces/pp4mp/</a>
+PayPal for Partners: <a href="https://developer.paypal.com/docs/partners/" target="_blank">https://developer.paypal.com/docs/partners/</a>
 
 <br />
 <br />

--- a/include/incl.readme.php
+++ b/include/incl.readme.php
@@ -1,7 +1,15 @@
 <h3>Readme</h3>
 
 <br />
-<b>Important:</b> PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. For more information, reach out to your PayPal account manager or <a href="https://www.paypal.com/us/webapps/mpp/partner-program/contact-us" target="_blank">contact us</a>.
+<b>Important:</b> PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. 
+<br>Two versions of the solution are available:<br>
+New integrations: <a href="https://developer.paypal.com/docs/partners/" target="_blank">version 2</a> (from February 2019)<br>
+Existing integrations: <a href="https://developer.paypal.com/docs/partners/v1/" target="_blank">version 1</a> (before February 2019)<br>
+New customers should integrate version 2. For more information, reach out to your PayPal account manager.<br><br>
+
+
+
+This code sample is not upgraded to use <a href="https://developer.paypal.com/docs/partners/" target="_blank">version 2</a>.
 <br/><br/>
 
 <h4>Getting Started</h4>


### PR DESCRIPTION
### Problem

'PayPal for Marketplaces' references need to be changed to 'PayPal for Partners' as per the new rebranding. Information about the new API version needs to be added.

### Solution
The new Product name 'PayPal for Partners' name added.
API version information with links to Developer Docs updated.
