### PR TITLE
PayPal Commerce Platform changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## PayPal for Partners Managed path
+## PayPal Commerce Platform Managed path
 
-> **Important:** PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. Two versions of the solution are available:
+> **Important:** PayPal Commerce Platform for eCommerce Solution Providers and Marketplaces is a limited-release solution at this time. It is available to select partners for approved use cases. Two versions of the solution are available:
 >
 >New integrations: [version 2](https://developer.paypal.com/docs/partners/) (from February 2019)
 >

--- a/include/incl.header.php
+++ b/include/incl.header.php
@@ -136,7 +136,7 @@
 		<div class="container-fluid">
 
             <div class="well bg-color">
-                <h2 class="text-center">PayPal for Partners &bull; <a href="../index.php#readme" class="light-links">Readme</a></h2>
+                <h2 class="text-center">PayPal Commerce Platform &bull; <a href="../index.php#readme" class="light-links">Readme</a></h2>
             </div>
             
         </div>

--- a/include/incl.indexheader.php
+++ b/include/incl.indexheader.php
@@ -136,7 +136,7 @@ $mode = (isset($_REQUEST["mode"]) &&  $_REQUEST["mode"] == "ma") ? "ma" : "isu";
 <div class="container-fluid">
 
     <div class="well bg-color">
-        <h2 class="text-center">PayPal for Partners &bull; <a href="#readme" class="light-links">Readme</a></h2>
+        <h2 class="text-center">PayPal Commerce Platform &bull; <a href="#readme" class="light-links">Readme</a></h2>
     </div>
 
 </div>

--- a/include/incl.readme.php
+++ b/include/incl.readme.php
@@ -1,7 +1,7 @@
 <h3>Readme</h3>
 
 <br />
-<b>Important:</b> PayPal for Partners is a limited-release solution at this time. It is available to select partners for approved use cases. 
+<b>Important:</b> PayPal Commerce Platform for eCommerce Solution Providers and Marketplaces is a limited-release solution at this time. It is available to select partners for approved use cases. 
 <br>Two versions of the solution are available:<br>
 New integrations: <a href="https://developer.paypal.com/docs/partners/" target="_blank">version 2</a> (from February 2019)<br>
 Existing integrations: <a href="https://developer.paypal.com/docs/partners/v1/" target="_blank">version 1</a> (before February 2019)<br>
@@ -13,7 +13,7 @@ This code sample is not upgraded to use <a href="https://developer.paypal.com/do
 <br/><br/>
 
 <h4>Getting Started</h4>
-This code sample serves as a reference for PayPal for Partners APIs. You will need your own PayPal Sandbox Partner credentials to run the code sample.
+This code sample serves as a reference for PayPal Commerce Platform APIs. You will need your own PayPal Sandbox Partner credentials to run the code sample.
 Once you have your Partner credentials, refer to the steps below:
 <br />
 <br />


### PR DESCRIPTION
### Problem

PayPal for Partners was rebranded

### Solution

Updated references to PayPal Commerce Platform
